### PR TITLE
[SM-40] change validation to accept multiple integrations on signals

### DIFF
--- a/internal/services/device_status_ingest_service.go
+++ b/internal/services/device_status_ingest_service.go
@@ -181,11 +181,13 @@ func (i *DeviceStatusIngestService) processEvent(_ goka.Context, event *DeviceSt
 
 	deviceData, err := models.UserDeviceData(
 		models.UserDeviceDatumWhere.UserDeviceID.EQ(userDeviceID),
+		models.UserDeviceDatumWhere.IntegrationID.EQ(integration.Id),
 		models.UserDeviceDatumWhere.Signals.IsNotNull(),
 		models.UserDeviceDatumWhere.UpdatedAt.GT(time.Now().Add(-14*24*time.Hour)),
 	).All(ctx, i.db().Reader)
+
 	if err != nil {
-		return fmt.Errorf("Internal error: %w", err)
+		return fmt.Errorf("internal error: %w", err)
 	}
 
 	if len(deviceData) > 0 {


### PR DESCRIPTION
# Proposed Changes
- add unit test for multiple and distinct integrations for a single user device
- change validation inside merger for signals
### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->