### PR TITLE
SI-2466-update-v1-endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -260,13 +260,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "startDate eg 2022-01-02. if empty two weeks back",
+                        "description": "startDate ex: 2022-01-02; or,  2022-01-02T09:00:00Z; if empty two weeks back",
                         "name": "startDate",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "endDate eg 2022-03-01. if empty today",
+                        "description": "endDate ex: 2022-03-01; or, 2023-03-01T09:00:00Z; if empty today",
                         "name": "endDate",
                         "in": "query"
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -251,13 +251,13 @@
                     },
                     {
                         "type": "string",
-                        "description": "startDate eg 2022-01-02. if empty two weeks back",
+                        "description": "startDate ex: 2022-01-02; or,  2022-01-02T09:00:00Z; if empty two weeks back",
                         "name": "startDate",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "endDate eg 2022-03-01. if empty today",
+                        "description": "endDate ex: 2022-03-01; or, 2023-03-01T09:00:00Z; if empty today",
                         "name": "endDate",
                         "in": "query"
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -570,11 +570,12 @@ paths:
         name: tokenID
         required: true
         type: integer
-      - description: startDate eg 2022-01-02. if empty two weeks back
+      - description: 'startDate ex: 2022-01-02; or,  2022-01-02T09:00:00Z; if empty
+          two weeks back'
         in: query
         name: startDate
         type: string
-      - description: endDate eg 2022-03-01. if empty today
+      - description: 'endDate ex: 2022-03-01; or, 2023-03-01T09:00:00Z; if empty today'
         in: query
         name: endDate
         type: string

--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -152,8 +152,8 @@ func addRangeIfNotExists(ctx context.Context, deviceDefSvc services.DeviceDefini
 // @Produce      json
 // @Success      200
 // @Param        tokenID  path   int64  true   "token id"
-// @Param        startDate     query  string  false  "startDate eg 2022-01-02. if empty two weeks back"
-// @Param        endDate       query  string  false  "endDate eg 2022-03-01. if empty today"
+// @Param        startDate     query  string  false  "startDate ex: 2022-01-02; or,  2022-01-02T09:00:00Z; if empty two weeks back"
+// @Param        endDate       query  string  false  "endDate ex: 2022-03-01; or, 2023-03-01T09:00:00Z; if empty today"
 // @Security     BearerAuth
 // @Router       /v1/vehicle/{tokenID}/history [get]
 func (d *DeviceDataController) GetHistoricalRawPermissioned(c *fiber.Ctx) error {

--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -157,25 +157,12 @@ func addRangeIfNotExists(ctx context.Context, deviceDefSvc services.DeviceDefini
 // @Security     BearerAuth
 // @Router       /v1/vehicle/{tokenID}/history [get]
 func (d *DeviceDataController) GetHistoricalRawPermissioned(c *fiber.Ctx) error {
-	const dateLayout = "2006-01-02" // date layout support by elastic
 	tokenID := c.Params("tokenID")
 	startDate := c.Query("startDate")
-	if startDate == "" {
-		startDate = time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(dateLayout) // if no startdate default to 2 weeks
-	} else {
-		_, err := time.Parse(dateLayout, startDate)
-		if err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
-	}
 	endDate := c.Query("endDate")
-	if endDate == "" {
-		endDate = time.Now().Format(dateLayout)
-	} else {
-		_, err := time.Parse(dateLayout, endDate)
-		if err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
+	startDate, endDate, err := parseDateRange(startDate, endDate)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
 	i, err := strconv.ParseInt(tokenID, 10, 64)
@@ -230,6 +217,7 @@ func (d *DeviceDataController) getHistoryV1(c *fiber.Ctx, userDevice *grpc.UserD
 		},
 		Size:    some.Int(1000),
 		Source_: &source,
+		Sort:    []types.SortCombinations{types.SortOptions{SortOptions: map[string]types.FieldSort{"data.timestamp": {Order: &sortorder.Asc}}}},
 	}
 
 	res, err := d.esService.ESClient().Search().Index(d.Settings.DeviceDataIndexName).Request(&req).Perform(c.Context())

--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -217,7 +217,6 @@ func (d *DeviceDataController) getHistoryV1(c *fiber.Ctx, userDevice *grpc.UserD
 		},
 		Size:    some.Int(1000),
 		Source_: &source,
-		Sort:    []types.SortCombinations{types.SortOptions{SortOptions: map[string]types.FieldSort{"data.timestamp": {Order: &sortorder.Asc}}}},
 	}
 
 	res, err := d.esService.ESClient().Search().Index(d.Settings.DeviceDataIndexName).Request(&req).Perform(c.Context())

--- a/internal/controllers/device_data_controller_test.go
+++ b/internal/controllers/device_data_controller_test.go
@@ -316,8 +316,8 @@ func TestUserDevicesController_GetVehicleStatusRaw(t *testing.T) {
 }
 
 func TestParseDateRange(t *testing.T) {
-
 	for _, c := range []struct {
+		name          string
 		originalStart string
 		originalEnd   string
 		expectedStart string
@@ -325,6 +325,7 @@ func TestParseDateRange(t *testing.T) {
 		valid         bool
 	}{
 		{
+			name:          "dateOnly",
 			originalStart: "2023-05-04",
 			originalEnd:   "2023-05-06",
 			valid:         true,
@@ -332,6 +333,7 @@ func TestParseDateRange(t *testing.T) {
 			expectedEnd:   "2023-05-06",
 		},
 		{
+			name:          "rfc3339",
 			originalStart: "2023-05-04T09:00:00Z",
 			originalEnd:   "2023-05-06T23:00:00Z",
 			valid:         true,
@@ -339,11 +341,10 @@ func TestParseDateRange(t *testing.T) {
 			expectedEnd:   "2023-05-06T23:00:00Z",
 		},
 		{
+			name:          "noValuesPassed",
 			originalStart: "",
 			originalEnd:   "",
 			valid:         true,
-			expectedStart: time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(time.RFC3339),
-			expectedEnd:   time.Now().Format(time.RFC3339),
 		},
 		{
 			originalStart: "2023-05-04T09:00:00",
@@ -358,6 +359,11 @@ func TestParseDateRange(t *testing.T) {
 		if !c.valid {
 			assert.Error(t, err)
 		} else {
+			if c.name == "noValuesPassed" {
+				assert.True(t, validDate(parsedStart))
+				assert.True(t, validDate(parsedEnd))
+				continue
+			}
 			assert.NoError(t, err)
 			assert.Equal(t, c.expectedStart, parsedStart)
 			assert.Equal(t, c.expectedEnd, parsedEnd)

--- a/internal/controllers/device_data_controller_test.go
+++ b/internal/controllers/device_data_controller_test.go
@@ -342,7 +342,7 @@ func TestParseDateRange(t *testing.T) {
 			originalStart: "",
 			originalEnd:   "",
 			valid:         true,
-			expectedStart: time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(dateLayout2),
+			expectedStart: time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(time.RFC3339),
 			expectedEnd:   time.Now().Format(time.RFC3339),
 		},
 		{

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -48,6 +48,7 @@ func getPrivileges(c *fiber.Ctx) []privileges.Privilege {
 }
 
 // parseDateRange validates whether the start and end date parameters are in an acceptable format, otherwise returns an error.
+// accepted formats include time.RFC3339 and time.DateOnly
 func parseDateRange(startDate, endDate string) (string, string, error) {
 	if startDate == "" {
 		startDate = time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(time.RFC3339) // if no startdate default to 2 weeks
@@ -68,11 +69,12 @@ func parseDateRange(startDate, endDate string) (string, string, error) {
 	return startDate, endDate, nil
 }
 
+// validDate returns true if date can be parsed as time.DateOnly or time.RFC3339
 func validDate(date string) bool {
-	_, errDateOnly := time.Parse(time.DateOnly, date)
-	if errDateOnly != nil {
-		_, errRFC3339 := time.Parse(time.RFC3339, date)
-		if errRFC3339 != nil {
+	_, err := time.Parse(time.DateOnly, date)
+	if err != nil {
+		_, err = time.Parse(time.RFC3339, date)
+		if err != nil {
 			return false
 		}
 	}

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -47,33 +47,34 @@ func getPrivileges(c *fiber.Ctx) []privileges.Privilege {
 	return privs
 }
 
-const dateLayout1 = time.DateOnly
-const dateLayout2 = time.RFC3339
-
+// parseDateRange validates whether the start and end date parameters are in an acceptable format, otherwise returns an error.
 func parseDateRange(startDate, endDate string) (string, string, error) {
 	if startDate == "" {
-		startDate = time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(dateLayout2) // if no startdate default to 2 weeks
+		startDate = time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(time.RFC3339) // if no startdate default to 2 weeks
 	} else {
-		_, errLayout1 := time.Parse(dateLayout1, startDate)
-		if errLayout1 != nil {
-			_, errLayout2 := time.Parse(dateLayout2, startDate)
-			if errLayout2 != nil {
-				return "", "", errLayout2
-			}
+		if !validDate(startDate) {
+			return "", "", fiber.NewError(fiber.StatusBadRequest, "Invalid start date format")
 		}
 	}
 
 	if endDate == "" {
-		endDate = time.Now().Format(dateLayout2)
+		endDate = time.Now().Format(time.RFC3339)
 	} else {
-		_, errLayout1 := time.Parse(dateLayout1, startDate)
-		if errLayout1 != nil {
-			_, errLayout2 := time.Parse(dateLayout2, endDate)
-			if errLayout2 != nil {
-				return "", "", errLayout2
-			}
+		if !validDate(endDate) {
+			return "", "", fiber.NewError(fiber.StatusBadRequest, "Invalid end date format")
 		}
 	}
 
 	return startDate, endDate, nil
+}
+
+func validDate(date string) bool {
+	_, errDateOnly := time.Parse(time.DateOnly, date)
+	if errDateOnly != nil {
+		_, errRFC3339 := time.Parse(time.RFC3339, date)
+		if errRFC3339 != nil {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/controllers/helpers.go
+++ b/internal/controllers/helpers.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"time"
+
 	"github.com/DIMO-Network/device-data-api/internal/services"
 	"github.com/DIMO-Network/shared/middleware/privilegetoken"
 	"github.com/DIMO-Network/shared/privileges"
@@ -43,4 +45,35 @@ func getPrivileges(c *fiber.Ctx) []privileges.Privilege {
 		privs[i] = privileges.Privilege(id)
 	}
 	return privs
+}
+
+const dateLayout1 = time.DateOnly
+const dateLayout2 = time.RFC3339
+
+func parseDateRange(startDate, endDate string) (string, string, error) {
+	if startDate == "" {
+		startDate = time.Now().Add(-1 * (time.Hour * 24 * 14)).Format(dateLayout2) // if no startdate default to 2 weeks
+	} else {
+		_, errLayout1 := time.Parse(dateLayout1, startDate)
+		if errLayout1 != nil {
+			_, errLayout2 := time.Parse(dateLayout2, startDate)
+			if errLayout2 != nil {
+				return "", "", errLayout2
+			}
+		}
+	}
+
+	if endDate == "" {
+		endDate = time.Now().Format(dateLayout2)
+	} else {
+		_, errLayout1 := time.Parse(dateLayout1, startDate)
+		if errLayout1 != nil {
+			_, errLayout2 := time.Parse(dateLayout2, endDate)
+			if errLayout2 != nil {
+				return "", "", errLayout2
+			}
+		}
+	}
+
+	return startDate, endDate, nil
 }


### PR DESCRIPTION
- Currently, v1 `/history` takes startDate and endDate (parsed as `time.DateOnly`); this makes it challenging to query for a specific trip, which requires more precision by trip start time and end time
- update v1 `/history` endpoint to accept time.RFC3339 in addition to time.DateOnly