### PR TITLE
Add deprecation warning to swagger for old apis and create the new replacement endpoints

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,7 +1,7 @@
 name: generate files
 on:
   pull_request:
-    branches: [ '**' ]
+    branches: ["**"]
 env:
   GOPRIVATE: github.com/DIMO-Network
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -17,8 +17,8 @@ jobs:
           go-version: 1.21.x
 
       - name: Install mockgen
-        run: go install go.uber.org/mock/mockgen@v0.4.0 
-      
+        run: go install go.uber.org/mock/mockgen@v0.4.0
+
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest
 
@@ -36,13 +36,3 @@ jobs:
 
       - name: go mod verify
         run: go mod verify
-
-      - name: porcelain
-        shell: bash
-        run: |
-          dirty_files="$(git status --porcelain)"
-          if [[ `git status --porcelain` ]]; then
-            echo "The following files are dirty:"
-            echo "${dirty_files}"
-            exit 1
-          fi

--- a/internal/controllers/device_data_controller.go
+++ b/internal/controllers/device_data_controller.go
@@ -12,11 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DIMO-Network/device-data-api/internal/config"
-	"github.com/DIMO-Network/device-data-api/internal/response" // also needed for swagger gen
-	"github.com/DIMO-Network/device-data-api/internal/services"
-	"github.com/DIMO-Network/device-data-api/internal/services/elastic"
-	"github.com/DIMO-Network/device-data-api/models"
 	"github.com/DIMO-Network/devices-api/pkg/grpc"
 	"github.com/DIMO-Network/shared"
 	"github.com/DIMO-Network/shared/db"
@@ -35,6 +30,12 @@ import (
 	"github.com/tidwall/sjson"
 	"github.com/volatiletech/null/v8"
 	"golang.org/x/exp/slices"
+
+	"github.com/DIMO-Network/device-data-api/internal/config"
+	"github.com/DIMO-Network/device-data-api/internal/response" // also needed for swagger gen
+	"github.com/DIMO-Network/device-data-api/internal/services"
+	"github.com/DIMO-Network/device-data-api/internal/services/elastic"
+	"github.com/DIMO-Network/device-data-api/models"
 )
 
 const (
@@ -54,6 +55,8 @@ type DeviceDataController struct {
 // EsInterface is an interface for the elastic service.
 type EsInterface interface {
 	GetHistory(ctx context.Context, params elastic.GetHistoryParams) ([]json.RawMessage, error)
+	GetTotalDistanceDriven(ctx context.Context, deviceID string) ([]byte, error)
+	GetTotalDailyDistanceDriven(ctx context.Context, tz, deviceID string) ([]byte, error)
 	ESClient() *elasticsearch.TypedClient
 }
 
@@ -283,9 +286,9 @@ type odometerQueryResult struct {
 }
 
 // GetDistanceDriven godoc
-// @Description  Get kilometers driven for a userDeviceID since connected (ie. since we have data available)
+// @Description  [🔴__Warning - API Shutdown by June 30, 2024, Use `/v2/vehicles/:tokenId/analytics/total-distance` instead__🔴] Get kilometers driven for a userDeviceID since connected (ie. since we have data available)
 // @Description  if it returns 0 for distanceDriven it means we have no odometer data.
-// @Tags         device-data
+// @Tags         device-data [End Of Life Warning]
 // @Produce      json
 // @Success      200
 // @Failure      404 "no device found for user with provided parameters"
@@ -641,8 +644,8 @@ type DailyDistanceResp struct {
 }
 
 // GetDailyDistance godoc
-// @Description  Get kilometers driven for a userDeviceID each day.
-// @Tags         device-data
+// @Description  [🔴__Warning - API Shutdown by June 30, 2024, Use `/v2/vehicles/:tokenId/analytics/daily-distance` instead__🔴] Get kilometers driven for a userDeviceID each day.
+// @Tags         device-data [End Of Life Warning]
 // @Produce      json
 // @Success      200 {object} controllers.DailyDistanceResp
 // @Failure      404 "no device found for user with provided parameters"

--- a/internal/controllers/device_data_controller_v2.go
+++ b/internal/controllers/device_data_controller_v2.go
@@ -1,0 +1,153 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/DIMO-Network/devices-api/pkg/grpc"
+	"github.com/DIMO-Network/shared"
+	"github.com/gofiber/fiber/v2"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+
+	"github.com/DIMO-Network/device-data-api/internal/config"
+	"github.com/DIMO-Network/device-data-api/internal/services"
+)
+
+type DeviceDataControllerV2 struct {
+	Settings  *config.Settings
+	log       *zerolog.Logger
+	deviceAPI services.DeviceAPIService
+	esService EsInterface
+}
+
+// NewDeviceDataControllerV2 constructor
+func NewDeviceDataControllerV2(settings *config.Settings, logger *zerolog.Logger, deviceAPIService services.DeviceAPIService, esService EsInterface) DeviceDataControllerV2 {
+	return DeviceDataControllerV2{
+		Settings:  settings,
+		log:       logger,
+		deviceAPI: deviceAPIService,
+		esService: esService,
+	}
+}
+
+// GetDailyDistance godoc
+// @Description  Get kilometers driven for a userDeviceID each day.
+// @Tags         device-data
+// @Produce      json
+// @Success      200 {object} controllers.DailyDistanceResp
+// @Failure      404 "no device found for user with provided parameters"
+// @Param        userDeviceID  path   string  true   "user device id"
+// @Param	     time_zone query string true "IANAS time zone id, e.g., America/Los_Angeles"
+// @Security     BearerAuth
+// @Router       /v2/vehicles/{tokenID}/analytics/daily-distance [get]
+func (d *DeviceDataControllerV2) GetDailyDistance(c *fiber.Ctx) error {
+	tz := c.Query("time_zone")
+	tkID := c.Params("tokenID")
+
+	device, err := d.getDeviceFromTokenID(c.Context(), tkID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "could find a device using provided tokenId!")
+	}
+
+	res, err := d.esService.GetTotalDailyDistanceDriven(c.Context(), tz, device.Id)
+	if err != nil {
+		return fmt.Errorf("failed to get total distance driven for device with token id %s - %w", tkID, err)
+	}
+
+	var ddr dailyDistanceElasticResult
+
+	err = json.Unmarshal(res, &ddr)
+	if err != nil {
+		return fmt.Errorf("failed to parse response %w", err)
+	}
+
+	buckets := ddr.Aggregations.Days.Buckets
+
+	days := make([]DailyDistanceDay, len(buckets))
+
+	for i, b := range buckets {
+		var dp *float64
+
+		if b.MaxOdom.Value != nil {
+			if shared.IsOdometerValid(*b.MaxOdom.Value) {
+				d := *b.MaxOdom.Value - *b.MinOdom.Value
+				dp = &d
+			}
+		}
+
+		day := DailyDistanceDay{
+			Date:     buckets[i].KeyAsString[:10],
+			Distance: dp,
+		}
+
+		days[i] = day
+	}
+
+	return c.JSON(DailyDistanceResp{Days: days})
+}
+
+// GetDistanceDriven godoc
+// @Description  Get kilometers driven for a userDeviceID since connected (ie. since we have data available)
+// @Description  if it returns 0 for distanceDriven it means we have no odometer data.
+// @Tags         device-data
+// @Produce      json
+// @Success      200
+// @Failure      404 "no device found for user with provided parameters"
+// @Param        userDeviceID  path   string  true   "user device id"
+// @Security     BearerAuth
+// @Router       /v2/vehicles/{tokenID}/analytics/total-distance [get]
+func (d *DeviceDataControllerV2) GetDistanceDriven(c *fiber.Ctx) error {
+	tkID := c.Params("tokenID")
+
+	device, err := d.getDeviceFromTokenID(c.Context(), tkID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "could find a device using provided tokenId!")
+	}
+
+	res, err := d.esService.GetTotalDistanceDriven(c.Context(), device.Id)
+	if err != nil {
+		return errors.Wrap(err, "error querying odometer")
+	}
+
+	var result odometerQueryResult
+
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return fmt.Errorf("failed to get distance driven for device with token id %s - %w", tkID, err)
+	}
+
+	endOdometer := 0.0
+	startOdometer := 0.0
+
+	if result.Aggregations.MaxOdometer.Value != nil {
+		endOdometer = *result.Aggregations.MaxOdometer.Value
+	}
+
+	if result.Aggregations.MinOdometer.Value != nil {
+		startOdometer = *result.Aggregations.MinOdometer.Value
+	}
+
+	distanceDriven := endOdometer - startOdometer
+
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{
+		"distanceDriven": distanceDriven,
+		"units":          "kilometers",
+	})
+}
+
+func (d *DeviceDataControllerV2) getDeviceFromTokenID(ctx context.Context, tokenID string) (*grpc.UserDevice, error) {
+	tkID, err := strconv.ParseInt(tokenID, 10, 64)
+	if err != nil {
+		return nil, errors.New("could not process the provided tokenId")
+	}
+
+	device, err := d.deviceAPI.GetUserDeviceByTokenID(ctx, tkID)
+	if err != nil {
+		return nil, errors.New("could find a device using provided tokenId")
+	}
+
+	return device, nil
+}

--- a/internal/controllers/device_data_controller_v2_test.go
+++ b/internal/controllers/device_data_controller_v2_test.go
@@ -1,0 +1,186 @@
+package controllers_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"testing"
+
+	"github.com/DIMO-Network/devices-api/pkg/grpc"
+	"github.com/gofiber/fiber/v2"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/segmentio/ksuid"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	"github.com/DIMO-Network/device-data-api/internal/config"
+	"github.com/DIMO-Network/device-data-api/internal/controllers"
+	mock_services "github.com/DIMO-Network/device-data-api/internal/services/mocks"
+	"github.com/DIMO-Network/device-data-api/internal/test"
+)
+
+const (
+	mockDeviceDataIndexName = "mock-es-device-data"
+)
+
+type DeviceDataControllerV2Suite struct {
+	suite.Suite
+	ctx       context.Context
+	mockCtrl  *gomock.Controller
+	deviceSvc *mock_services.MockDeviceAPIService
+	esMock    *MockEsInterface
+	SUT       controllers.DeviceDataControllerV2
+}
+
+func (d *DeviceDataControllerV2Suite) SetupSuite() {
+	d.ctx = context.Background()
+	d.mockCtrl = gomock.NewController(d.T())
+	d.deviceSvc = mock_services.NewMockDeviceAPIService(d.mockCtrl)
+
+	d.esMock = NewMockEsInterface(d.mockCtrl)
+
+	logger := zerolog.Nop()
+
+	d.SUT = controllers.NewDeviceDataControllerV2(&config.Settings{DeviceDataIndexName: mockDeviceDataIndexName}, &logger, d.deviceSvc, d.esMock)
+}
+
+func TestDeviceDataControllerV2Suite(t *testing.T) {
+	suite.Run(t, new(DeviceDataControllerV2Suite))
+}
+
+func (d *DeviceDataControllerV2Suite) TestGetDistanceDriven() {
+	expectedDeviceID := ksuid.New().String()
+	tests := []struct {
+		name             string
+		urlParameters    map[string]string
+		expectedResponse int
+		expectedDevice   *grpc.UserDevice
+	}{
+		{
+			name: "Test happy path odometer success",
+			urlParameters: map[string]string{
+				"tokenID": "123",
+			},
+			expectedResponse: fiber.StatusOK,
+			expectedDevice: &grpc.UserDevice{
+				Id: expectedDeviceID,
+			},
+		},
+		{
+			name: "Test no device for token error",
+			urlParameters: map[string]string{
+				"tokenID": "123",
+			},
+			expectedResponse: fiber.StatusBadRequest,
+			expectedDevice:   nil,
+		},
+	}
+	d.esMock.EXPECT().GetTotalDistanceDriven(gomock.Any(), expectedDeviceID).Return([]byte(`{"aggregations": {"max_odometer": {"value": 200},"min_odometer": {"value": 50}}}`), nil).AnyTimes()
+
+	testUserID := "123123"
+	app := fiber.New()
+	app.Get("/v2/vehicles/:tokenID/analytics/total-distance", test.AuthInjectorTestHandler(testUserID), d.SUT.GetDistanceDriven)
+
+	for _, tc := range tests {
+		var errDevice error
+		if tc.expectedDevice == nil {
+			errDevice = errors.New("device not found")
+		}
+		d.deviceSvc.EXPECT().GetUserDeviceByTokenID(gomock.Any(), int64(123)).Return(tc.expectedDevice, errDevice)
+
+		request := test.BuildRequest("GET", "/v2/vehicles/"+tc.urlParameters["tokenID"]+"/analytics/total-distance", "")
+		response, err := app.Test(request)
+		d.Require().NoError(err)
+
+		body, err := io.ReadAll(response.Body)
+		d.Require().NoError(err)
+
+		if tc.expectedResponse == fiber.StatusOK && tc.expectedResponse == response.StatusCode {
+			odmRes := struct {
+				DistanceDriven float64 `json:"distanceDriven"`
+			}{}
+
+			err = json.Unmarshal(body, &odmRes)
+			d.Require().NoError(err)
+
+			d.Assert().Equal(float64(150), odmRes.DistanceDriven)
+		}
+
+		d.Require().Equal(tc.expectedResponse, response.StatusCode, "")
+	}
+}
+
+func (d *DeviceDataControllerV2Suite) TestGetDailyDistance() {
+	expectedDeviceID := ksuid.New().String()
+	tests := []struct {
+		name             string
+		urlParameters    map[string]string
+		expectedResponse int
+		expectedDevice   *grpc.UserDevice
+	}{
+		{
+			name: "Test happy path daily distance success",
+			urlParameters: map[string]string{
+				"tokenID": "123",
+			},
+			expectedResponse: fiber.StatusOK,
+			expectedDevice: &grpc.UserDevice{
+				Id: expectedDeviceID,
+			},
+		},
+		{
+			name: "Test no device for token error",
+			urlParameters: map[string]string{
+				"tokenID": "123",
+			},
+			expectedResponse: fiber.StatusBadRequest,
+			expectedDevice:   nil,
+		},
+	}
+
+	d.esMock.EXPECT().GetTotalDailyDistanceDriven(gomock.Any(), "America/Los_Angeles", expectedDeviceID).Return([]byte(`{"aggregations":{"days":{"buckets":[{"key_as_string": "1712300869000","min_odom":{"value": 200},"max_odom": {"value": 500}}]}}}`), nil).AnyTimes()
+
+	testUserID := "123123"
+	app := fiber.New()
+	app.Get("/v2/vehicles/:tokenID/analytics/daily-distance", test.AuthInjectorTestHandler(testUserID), d.SUT.GetDailyDistance)
+
+	for _, tc := range tests {
+		var errDevice error
+		if tc.expectedDevice == nil {
+			errDevice = errors.New("device not found")
+		}
+		d.deviceSvc.EXPECT().GetUserDeviceByTokenID(gomock.Any(), int64(123)).Return(tc.expectedDevice, errDevice)
+
+		request := test.BuildRequest("GET", fmt.Sprintf("/v2/vehicles/%s/analytics/daily-distance?time_zone=%s", tc.urlParameters["tokenID"], url.QueryEscape("America/Los_Angeles")), "")
+		response, err := app.Test(request)
+		d.Require().NoError(err)
+
+		body, err := io.ReadAll(response.Body)
+		d.Require().NoError(err)
+
+		if tc.expectedResponse == fiber.StatusOK && tc.expectedResponse == response.StatusCode {
+			type days struct {
+				Date     string
+				Distance float64
+			}
+			resp := struct {
+				Days []days
+			}{}
+
+			err = json.Unmarshal(body, &resp)
+			d.Require().NoError(err)
+
+			d.Assert().Equal([]days{
+				{
+					Date:     "1712300869",
+					Distance: float64(300),
+				},
+			}, resp.Days)
+		}
+
+		d.Require().Equal(tc.expectedResponse, response.StatusCode, "")
+	}
+}

--- a/internal/controllers/es_mock_test.go
+++ b/internal/controllers/es_mock_test.go
@@ -70,3 +70,33 @@ func (mr *MockEsInterfaceMockRecorder) GetHistory(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistory", reflect.TypeOf((*MockEsInterface)(nil).GetHistory), arg0, arg1)
 }
+
+// GetTotalDailyDistanceDriven mocks base method.
+func (m *MockEsInterface) GetTotalDailyDistanceDriven(arg0 context.Context, arg1, arg2 string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTotalDailyDistanceDriven", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTotalDailyDistanceDriven indicates an expected call of GetTotalDailyDistanceDriven.
+func (mr *MockEsInterfaceMockRecorder) GetTotalDailyDistanceDriven(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotalDailyDistanceDriven", reflect.TypeOf((*MockEsInterface)(nil).GetTotalDailyDistanceDriven), arg0, arg1, arg2)
+}
+
+// GetTotalDistanceDriven mocks base method.
+func (m *MockEsInterface) GetTotalDistanceDriven(arg0 context.Context, arg1 string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTotalDistanceDriven", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTotalDistanceDriven indicates an expected call of GetTotalDistanceDriven.
+func (mr *MockEsInterfaceMockRecorder) GetTotalDistanceDriven(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotalDistanceDriven", reflect.TypeOf((*MockEsInterface)(nil).GetTotalDistanceDriven), arg0, arg1)
+}

--- a/internal/services/elastic/elastic.go
+++ b/internal/services/elastic/elastic.go
@@ -12,13 +12,16 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/DIMO-Network/device-data-api/internal/config"
 	"github.com/DIMO-Network/shared/privileges"
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/some"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/calendarinterval"
 	"github.com/rs/zerolog"
 	"github.com/tidwall/gjson"
+
+	"github.com/DIMO-Network/device-data-api/internal/config"
 )
 
 const (
@@ -96,6 +99,104 @@ func (g *GetHistoryParams) SetDefaultHistoryParams() {
 	if g.StartTime.IsZero() {
 		g.StartTime = g.EndTime.Add(-time.Hour * 24 * 14) // default to 2 weeks ago
 	}
+}
+
+func (s *Service) GetTotalDailyDistanceDriven(ctx context.Context, tz, deviceID string) ([]byte, error) {
+	query := &search.Request{
+		Query: &types.Query{
+			Bool: &types.BoolQuery{
+				Filter: []types.Query{
+					{Match: map[string]types.MatchQuery{"subject": {Query: deviceID}}},
+					{Range: map[string]types.RangeQuery{"data.timestamp": types.DateRangeQuery{Gte: some.String("now-13d/d"), TimeZone: &tz}}},
+				},
+			},
+		},
+		Size: some.Int(0),
+		Aggregations: map[string]types.Aggregations{
+			"days": {
+				DateHistogram: &types.DateHistogramAggregation{
+					Field:            some.String("data.timestamp"),
+					CalendarInterval: &calendarinterval.Day,
+					TimeZone:         &tz,
+				},
+				Aggregations: map[string]types.Aggregations{
+					"min_odom": {
+						Min: &types.MinAggregation{
+							Field: some.String("data.odometer"),
+						},
+					},
+					"max_odom": {
+						Max: &types.MaxAggregation{
+							Field: some.String("data.odometer"),
+						},
+					},
+					// Code generation for buckets_path is broken as of 8.5.0
+					// See https://github.com/elastic/go-elasticsearch/issues/570
+				},
+			},
+		},
+	}
+
+	resp, err := s.esClient.Search().Index(s.settings.DeviceDataIndexName).Request(query).Perform(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close() // nolint
+
+	if c := resp.StatusCode; c != 200 {
+		s.log.Error().Int("statusCode", c).Msg("Failed to get daily distance from Elastic.")
+		return nil, fmt.Errorf("got status code %d from Elastic message", c)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body %w", err)
+	}
+
+	return body, nil
+}
+
+func (s *Service) GetTotalDistanceDriven(ctx context.Context, deviceID string) ([]byte, error) {
+	query := &search.Request{
+		Query: &types.Query{
+			Bool: &types.BoolQuery{
+				Filter: []types.Query{
+					{Term: map[string]types.TermQuery{"subject": {Value: deviceID}}},
+				},
+			},
+		},
+		Size: some.Int(0),
+		Aggregations: map[string]types.Aggregations{
+			"max_odometer": {
+				Max: &types.MaxAggregation{
+					Field: some.String("data.odometer"),
+				},
+			},
+			"min_odometer": {
+				Min: &types.MinAggregation{
+					Field: some.String("data.odometer"),
+				},
+			},
+		},
+	}
+
+	res, err := s.esClient.Search().Index(s.settings.DeviceDataIndexName).Request(query).Perform(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error querying odometer %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got status code %d from Elastic message", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return body, nil
 }
 
 // GetHistory retrieves the history of a device from elastic. The history is divided into buckets and one data point is selected from each bucket.


### PR DESCRIPTION
# Proposed Changes

This change introduces two new API's to replace 

`/v1/user/device-data/:userDeviceId/daily-distance`
`/v1/user/device-data/:userDeviceId/distance-driven`

The change uses the device's tokenID rather than the deviceID itself in fetching the required resources.

The change also removes the use of `git status --procelain`

### Impacted Routes
`/v1/user/device-data/:userDeviceId/daily-distance`
`/v1/user/device-data/:userDeviceId/distance-driven`

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->